### PR TITLE
kodi-prevent-xscreensaver: convert to POSIX and use `sleep` to start while loop

### DIFF
--- a/common/kodi-prevent-xscreensaver
+++ b/common/kodi-prevent-xscreensaver
@@ -1,17 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 # Emulate the mplayer hearbeat-cmd to keep xscreensaver from coming on while the kodi gui is active.
 # Inspiration from this post: http://ubuntuforums.org/showthread.php?t=1931074&p=11716198#post11716198
 
 # Nothing to do if user does not have requisite binaries.
-[[ -z $(which xscreensaver-command) ]] && exit 1
+[ -z $(which xscreensaver-command) ] && exit 1
 
-while true; do
-	if [[ -n $(pidof kodi-x11) ]]; then
-		while [[ -n $(pidof kodi-x11) ]]; do
-			xscreensaver-command -deactivate &>/dev/null
-			sleep 49s
-		done
-	else
-		sleep 49s
-	fi
+while sleep 49; do
+   if [ -n "$(pgrep kodi)" ]; then
+      xscreensaver-command -deactivate > /dev/null 2>&1
+   fi
 done


### PR DESCRIPTION
Although `/bin/sh` is linked to `bash` in a stock Arch system this modification will make the script run faster with less overhead for people who re-link `/bin/sh` to `dash`. It also ensures portability to other distributions that link `/bin/sh` to `dash` OOTB.

Initiating the `while` loop with the `sleep` command also reduces overhead and increases speed. Slightly :-)